### PR TITLE
Conditional assignment on PREFIX definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 SRC = src/mon.c deps/ms/ms.c deps/commander/src/commander.c
 OBJ = $(SRC:.c=.o)
 CFLAGS = -D_GNU_SOURCE -std=c99 -I deps/ms -I deps/commander/src


### PR DESCRIPTION
This allows PREFIX to be overridden to install mon in another location when calling make.

ie:

```
PREFIX=/my/custom/path make install
```
