### PR TITLE
Pass the PID (and other information?) to the on-error script/program executed.

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -218,9 +218,11 @@ daemonize() {
  */
 
 void
-exec_restart_command(monitor_t *monitor) {
-  log("on restart `%s`", monitor->on_restart);
-  int status = system(monitor->on_restart);
+exec_restart_command(monitor_t *monitor, pid_t pid) {
+  char buf[256] = {0};
+  snprintf(buf, 256, "%s %d", monitor->on_restart, pid);
+  log("on restart `%s`", buf);
+  int status = system(buf);
   if (status) log("exit(%d)", status);
 }
 
@@ -322,7 +324,7 @@ exec: {
 
       // restart
       error: {
-        if (monitor->on_restart) exec_restart_command(monitor);
+        if (monitor->on_restart) exec_restart_command(monitor, pid);
         int64_t ms = ms_since_last_restart(monitor);
         monitor->last_restart_at = timestamp();
         log("last restart %s ago", milliseconds_to_long_string(ms));


### PR DESCRIPTION
I made the on-error command pass along the PID of the failing process, even if that isn't really useful. 
It's more of a suggestion than an actual pull-request, mainly because I have very little knowledge of C and this is probably done in a bad way! :) It does work fine though.

``` bash
kristoffer@dev:~/code/mon$ ./mon "echo hello" --attempts 3 --on-error "echo $1 hello"
mon : child 6674
mon : sh -c "echo hello"
hello
mon : last restart less than one second ago
mon : 3 attempts remaining
mon : child 6675
mon : sh -c "echo hello"
hello
mon : last restart less than one second ago
mon : 2 attempts remaining
mon : child 6676
mon : sh -c "echo hello"
hello
mon : last restart less than one second ago
mon : 1 attempts remaining
mon : 3 restarts within less than one second, bailing
mon : on error `echo  hello 6676`
hello 6676
mon : bye :)
```

I have also added the on-error argument to mongroup, so we can have some basic error reporting there. Since mon only really knows the PID, it might be better to have mongroup pass in the command + some arguments of its own with process-name or something like that to be able to get more detailed information into the error-reporting emails (or other error logging processes).

Anyway, I hope this is useful and that someone else agrees with my suggestion!
