### PR TITLE
Makefile: improve compatibility with BSD make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ OBJ = $(SRC:.c=.o)
 CFLAGS = -D_GNU_SOURCE -std=c99 -I deps/
 
 mon: $(OBJ)
-	$(CC) $^ -o $@
+	$(CC) $(OBJ) -o $@
 
-%.o: %.c
+.SUFFIXES: .c .o
+.c.o:
 	$(CC) $< $(CFLAGS) -c -o $@
 
 install: mon


### PR DESCRIPTION
The Makefile contained a couple instances of GNU make specific
syntax. This caused a build error when using BSD make. This
was reported in Issue 29 https://github.com/visionmedia/mon/issues/29

BSD make wasn't setting $^ in the mon target, so the object files
weren't being listed in the compile command. This is fixed by
replacing $^ with $(OBJ).

BSD make was outputting the object files to the current directory
instead of the src and deps directories as expected due to the
way the generic .c to .o rules were written. This patch rewrites
that rule so that BSD make outputs the object files to the proper
sub-directory.

Tested on NetBSD and Linux with GNU make 3.82 and BSD make 20110606.
